### PR TITLE
Add GET /api/user/measurements endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ The gateway is configured via **command-line arguments** (not environment variab
 
 - `GET /api/user/me` - Get user probe daily usage statistics
 - `GET /api/user/prefixes` - List user prefixes per agent
+- `GET /api/user/measurements` - List the user's recent measurements (optional `?limit=`, default 20, max 100)
 - `POST /api/probes` - Submit probes for measurement
-- `GET /api/measurements/{id}/status` - Get measurement status
+- `GET /api/measurement/{id}/status` - Get measurement status
 
 ### Agent API (requires agent key)
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -737,6 +737,78 @@ impl Database {
         }
     }
 
+    /// List a user's most recent measurements, newest first.
+    pub async fn list_user_measurements(
+        &self,
+        user_hash: &str,
+        limit: i32,
+    ) -> Result<Vec<MeasurementStatus>, sqlx::Error> {
+        match &self.impl_ {
+            DatabaseImpl::Real(pool) => {
+                let measurements = sqlx::query_as::<_, MeasurementStatus>(
+                    r#"SELECT
+                       measurement_id,
+                       user_hash,
+                       total_agents,
+                       total_expected_probes,
+                       total_sent_probes,
+                       completed_agents,
+                       measurement_complete,
+                       started_at,
+                       last_updated
+                       FROM measurement_status
+                       WHERE user_hash = $1
+                       ORDER BY last_updated DESC
+                       LIMIT $2"#,
+                )
+                .bind(user_hash)
+                .bind(limit)
+                .fetch_all(pool)
+                .await?;
+
+                Ok(measurements)
+            }
+            DatabaseImpl::Mock(storage) => {
+                let tracking = storage.measurement_tracking.lock().unwrap();
+
+                // Aggregate the per-agent tracking rows into one status per
+                // measurement, mirroring the `measurement_status` SQL view.
+                let mut by_measurement: std::collections::HashMap<Uuid, Vec<&MeasurementTracking>> =
+                    std::collections::HashMap::new();
+                for t in tracking.iter().filter(|t| t.user_hash == user_hash) {
+                    by_measurement.entry(t.measurement_id).or_default().push(t);
+                }
+
+                let mut measurements: Vec<MeasurementStatus> = by_measurement
+                    .into_iter()
+                    .map(|(measurement_id, records)| {
+                        let total_agents = records.len() as i64;
+                        let completed_agents =
+                            records.iter().filter(|r| r.is_complete).count() as i64;
+                        MeasurementStatus {
+                            measurement_id,
+                            user_hash: user_hash.to_string(),
+                            total_agents,
+                            total_expected_probes: records
+                                .iter()
+                                .map(|r| r.expected_probes as i64)
+                                .sum(),
+                            total_sent_probes: records.iter().map(|r| r.sent_probes as i64).sum(),
+                            completed_agents,
+                            measurement_complete: completed_agents == total_agents,
+                            started_at: records.iter().map(|r| r.created_at).min().unwrap(),
+                            last_updated: records.iter().map(|r| r.updated_at).max().unwrap(),
+                        }
+                    })
+                    .collect();
+
+                measurements.sort_by(|a, b| b.last_updated.cmp(&a.last_updated));
+                measurements.truncate(limit as usize);
+                Ok(measurements)
+            }
+        }
+    }
+
     /// Get all measurement tracking entries for a measurement
     pub async fn get_measurement_tracking(
         &self,
@@ -1148,6 +1220,58 @@ mod tests {
             assert_eq!(tracking.sent_probes, 100);
             assert!(tracking.is_complete);
         }
+    }
+
+    #[tokio::test]
+    async fn test_list_user_measurements() {
+        let db = Database::new_mock();
+        db.initialize().await.unwrap();
+
+        let user_hash = "test_user_hash";
+        let other_user_hash = "other_user_hash";
+
+        // First measurement: two agents, one complete.
+        let m1 = Uuid::new_v4();
+        db.create_measurement_tracking(user_hash, m1, "agent1", 100)
+            .await
+            .unwrap();
+        db.create_measurement_tracking(user_hash, m1, "agent2", 100)
+            .await
+            .unwrap();
+        db.update_measurement_probe_count(m1, user_hash, "agent1", 100, true)
+            .await
+            .unwrap();
+
+        // Second measurement (touched later, so it should sort first).
+        let m2 = Uuid::new_v4();
+        db.create_measurement_tracking(user_hash, m2, "agent1", 10)
+            .await
+            .unwrap();
+        db.update_measurement_probe_count(m2, user_hash, "agent1", 10, true)
+            .await
+            .unwrap();
+
+        // A different user's measurement must not leak into the list.
+        let m3 = Uuid::new_v4();
+        db.create_measurement_tracking(other_user_hash, m3, "agent1", 5)
+            .await
+            .unwrap();
+
+        let measurements = db.list_user_measurements(user_hash, 20).await.unwrap();
+
+        // Only this user's two measurements, newest (m2) first.
+        assert_eq!(measurements.len(), 2);
+        assert_eq!(measurements[0].measurement_id, m2);
+        assert!(measurements[0].measurement_complete);
+        assert_eq!(measurements[1].measurement_id, m1);
+        assert_eq!(measurements[1].total_agents, 2);
+        assert_eq!(measurements[1].completed_agents, 1);
+        assert!(!measurements[1].measurement_complete);
+
+        // The limit caps the number of returned measurements.
+        let limited = db.list_user_measurements(user_hash, 1).await.unwrap();
+        assert_eq!(limited.len(), 1);
+        assert_eq!(limited[0].measurement_id, m2);
     }
 
     #[tokio::test]

--- a/src/database.rs
+++ b/src/database.rs
@@ -1242,6 +1242,12 @@ mod tests {
             .await
             .unwrap();
 
+        // The Mock derives `last_updated` from `Utc::now()`, so a real (small)
+        // delay is needed to guarantee m2 sorts strictly before m1 — two
+        // consecutive in-memory ops can otherwise tie on the same instant and
+        // make the order of the pair non-deterministic.
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+
         // Second measurement (touched later, so it should sort first).
         let m2 = Uuid::new_v4();
         db.create_measurement_tracking(user_hash, m2, "agent1", 10)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub mod probe_capnp;
 
 use axum::{
     Router,
-    extract::{Extension, Path, Request, State},
+    extract::{Extension, Path, Query, Request, State},
     http::StatusCode,
     middleware::Next,
     response::Json,
@@ -46,6 +46,7 @@ pub fn create_client_app(state: AppState) -> Router {
     let protected_routes = Router::new()
         .route("/user/me", get(get_user_info))
         .route("/user/prefixes", get(get_user_prefixes))
+        .route("/user/measurements", get(list_measurements_handler))
         .route("/probes", post(submit_probes))
         .route(
             "/measurement/{id}/status",
@@ -625,6 +626,57 @@ async fn submit_probes(
         probes: total_probe_count,
         agents: assigned_agents,
     }))
+}
+
+// Query parameters for listing a user's measurements
+#[derive(serde::Deserialize)]
+struct ListMeasurementsQuery {
+    limit: Option<i32>,
+}
+
+// Handler for listing the authenticated user's recent measurements (client-facing)
+async fn list_measurements_handler(
+    Extension(auth_info): Extension<jwt::AuthInfo>,
+    State(state): State<AppState>,
+    Query(params): Query<ListMeasurementsQuery>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let user_hash = crate::hash_user_identifier(&auth_info.sub);
+    let limit = params.limit.unwrap_or(20).clamp(1, 100);
+
+    match state
+        .database
+        .list_user_measurements(&user_hash, limit)
+        .await
+    {
+        Ok(measurements) => {
+            let items: Vec<_> = measurements
+                .into_iter()
+                .map(|m| {
+                    serde_json::json!({
+                        "measurement_id": m.measurement_id,
+                        "total_agents": m.total_agents,
+                        "completed_agents": m.completed_agents,
+                        "total_expected_probes": m.total_expected_probes,
+                        "total_sent_probes": m.total_sent_probes,
+                        "measurement_complete": m.measurement_complete,
+                        "started_at": m.started_at,
+                        "last_updated": m.last_updated
+                    })
+                })
+                .collect();
+            Ok(Json(serde_json::Value::Array(items)))
+        }
+        Err(err) => {
+            error!("Failed to list measurements: {}", err);
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": 500,
+                    "message": "Failed to retrieve measurements"
+                })),
+            ))
+        }
+    }
 }
 
 // Handler for getting measurement status (client-facing)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -628,10 +628,13 @@ async fn submit_probes(
     }))
 }
 
-// Query parameters for listing a user's measurements
+// Query parameters for listing a user's measurements.
+// `limit` is taken as a raw string and parsed in the handler so that malformed
+// input returns the standard JSON error shape rather than Axum's plain-text
+// query-rejection (which would be inconsistent with the rest of the API).
 #[derive(serde::Deserialize)]
 struct ListMeasurementsQuery {
-    limit: Option<i32>,
+    limit: Option<String>,
 }
 
 // Handler for listing the authenticated user's recent measurements (client-facing)
@@ -641,7 +644,21 @@ async fn list_measurements_handler(
     Query(params): Query<ListMeasurementsQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
     let user_hash = crate::hash_user_identifier(&auth_info.sub);
-    let limit = params.limit.unwrap_or(20).clamp(1, 100);
+    let limit = match params.limit.as_deref() {
+        None | Some("") => 20,
+        Some(raw) => match raw.parse::<i64>() {
+            Ok(n) => n.clamp(1, 100) as i32,
+            Err(_) => {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "error": 400,
+                        "message": "Invalid 'limit' query parameter: expected an integer between 1 and 100"
+                    })),
+                ));
+            }
+        },
+    };
 
     match state
         .database


### PR DESCRIPTION
## What

Adds a JWT-scoped `GET /api/user/measurements` endpoint that lists the authenticated user's most recent measurements, aggregated from the existing `measurement_status` view (ordered by `last_updated DESC`). Supports an optional `?limit=` query param (default 20, clamped 1–100).

Until now the only measurement handle was `GET /measurement/{id}/status` for a single known ID. ClickHouse `saimiris.replies` has no `measurement_id`, so this metadata only lives here in Postgres — hence a new endpoint rather than a CLI-only change.

## Changes

- `database.rs` — `list_user_measurements(user_hash, limit)` (Real SQL against `measurement_status` + Mock impl) with a unit test (`test_list_user_measurements`) covering user-scoping, newest-first ordering, and the limit cap.
- `lib.rs` — `GET /api/user/measurements` handler (placed under `/user/*` alongside `me`/`prefixes`), JWT-scoped via the same `hash_user_identifier(&auth_info.sub)` pattern as the status handler.
- `README.md` — documents the endpoint (and fixes a pre-existing singular/plural drift on the status route).

## Why

Backs the new `nxthdr probing measurements` CLI command — part of the v2 CLI "Probing ergonomics" scope in nxthdr/roadmap#38 ("list your recent measurements so the ID from `send` isn't the only handle").

## Testing

`cargo test --lib` → 26 passed; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)