### PR TITLE
ci: add advisory Claude Review on PR open

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,49 @@
+name: Claude Review
+
+# Runs once, when the PR is opened. To re-review after changes,
+# mention @claude in a PR comment (handled by claude.yml).
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  review:
+    # Skip bot-authored PRs (Renovate, Dependabot, etc.):
+    #  - user.type != 'Bot' catches app-based bots (renovate[bot], dependabot[bot])
+    #  - the head_ref prefixes catch self-hosted bots running under a normal account
+    if: >-
+      github.event.pull_request.user.type != 'Bot' &&
+      !startsWith(github.head_ref, 'renovate/') &&
+      !startsWith(github.head_ref, 'dependabot/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          token: ${{ secrets.CLAUDE_GITHUB_PAT }}
+
+      - name: Run Claude Review
+        uses: anthropics/claude-code-action@v1
+        # The review is advisory: it posts findings but must never block a PR.
+        # claude-code-action exits non-zero when it hits --max-turns, so without
+        # this the job goes red even though the review ran. Keep CI green and let
+        # the posted review speak for itself.
+        continue-on-error: true
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.CLAUDE_GITHUB_PAT }}
+          track_progress: true
+          prompt: |
+            Review PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
+            Focus on logic bugs, security issues, and violations of our CLAUDE.md
+            conventions. Report important findings only; skip nits. Use inline
+            comments on the relevant lines where it helps.
+          claude_args: |
+            --max-turns 20


### PR DESCRIPTION
Adds the same review-on-open workflow used in [nxthdr/cli](https://github.com/nxthdr/cli/blob/main/.github/workflows/claude-review.yml): when a PR is opened, Claude posts a code-review comment focused on logic bugs, security, and convention violations.

- **Advisory only** — `continue-on-error: true` means a `--max-turns` stop (or any action error) never turns the PR check red; the posted review speaks for itself.
- `--max-turns 20` + `timeout-minutes: 15` give the review room to finish.
- Uses the existing `CLAUDE_CODE_OAUTH_TOKEN` / `CLAUDE_GITHUB_PAT` secrets (already used by `claude.yml`). Re-review after changes via an `@claude` comment, handled by the existing `claude.yml`.

> Note: this repo has no `CLAUDE.md`, so the prompt's "CLAUDE.md conventions" clause is currently a no-op — the bug/security focus still applies. Adding a `CLAUDE.md` later would make convention-checking effective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)