### PR TITLE
refactor: rename /api/user/measurements → /api/measurements

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ The gateway is configured via **command-line arguments** (not environment variab
 
 - `GET /api/user/me` - Get user probe daily usage statistics
 - `GET /api/user/prefixes` - List user prefixes per agent
-- `GET /api/user/measurements` - List the user's recent measurements (optional `?limit=`, default 20, max 100)
 - `POST /api/probes` - Submit probes for measurement
+- `GET /api/measurements` - List the user's recent measurements (optional `?limit=`, default 20, max 100)
 - `GET /api/measurement/{id}/status` - Get measurement status
 
 ### Agent API (requires agent key)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub fn create_client_app(state: AppState) -> Router {
     let protected_routes = Router::new()
         .route("/user/me", get(get_user_info))
         .route("/user/prefixes", get(get_user_prefixes))
-        .route("/user/measurements", get(list_measurements_handler))
+        .route("/measurements", get(list_measurements_handler))
         .route("/probes", post(submit_probes))
         .route(
             "/measurement/{id}/status",


### PR DESCRIPTION
Follow-up to #42. Drops the inconsistent `/user/` prefix from the measurements list endpoint.

**Before** (inconsistent — only the list was under `/user/`):
```
GET /api/user/measurements
GET /api/measurement/{id}/status
```
**After** (both in the top-level measurement namespace, parallel to `/api/agents` + `/api/agent/{id}`):
```
GET /api/measurements
GET /api/measurement/{id}/status
```

Safe to rename now: #42 isn't deployed and the only client (nxthdr CLI, PR #14) isn't released yet — its call site is updated in lockstep. `cargo check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)