### PR TITLE
Add POST /api/measurement/{id}/cancel

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The gateway is configured via **command-line arguments** (not environment variab
 - `POST /api/probes` - Submit probes for measurement
 - `GET /api/measurements` - List the user's recent measurements (optional `?limit=`, default 20, max 100)
 - `GET /api/measurement/{id}/status` - Get measurement status
+- `POST /api/measurement/{id}/cancel` - Cancel a stuck/in-progress measurement (marks its unfinished agents cancelled)
 
 ### Agent API (requires agent key)
 

--- a/migrations/20260619000001_add_measurement_cancellation.sql
+++ b/migrations/20260619000001_add_measurement_cancellation.sql
@@ -1,0 +1,27 @@
+-- Add measurement cancellation support.
+-- A user can cancel a stuck/in-progress measurement; its not-yet-complete agent
+-- rows are marked `cancelled`, which makes the measurement terminal so it stops
+-- showing as "in progress" forever (e.g. when an agent dies mid-run).
+
+ALTER TABLE measurement_tracking
+    ADD COLUMN IF NOT EXISTS cancelled BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Recreate the status view: a measurement is terminal ("complete") when every
+-- agent is either complete or cancelled, and expose whether it was cancelled.
+CREATE OR REPLACE VIEW measurement_status AS
+SELECT
+    measurement_id,
+    user_hash,
+    COUNT(*) as total_agents,
+    SUM(expected_probes) as total_expected_probes,
+    SUM(sent_probes) as total_sent_probes,
+    COUNT(*) FILTER (WHERE is_complete = TRUE) as completed_agents,
+    CASE
+        WHEN COUNT(*) FILTER (WHERE is_complete = TRUE OR cancelled = TRUE) = COUNT(*) THEN TRUE
+        ELSE FALSE
+    END as measurement_complete,
+    bool_or(cancelled) as measurement_cancelled,
+    MIN(created_at) as started_at,
+    MAX(updated_at) as last_updated
+FROM measurement_tracking
+GROUP BY measurement_id, user_hash;

--- a/src/database.rs
+++ b/src/database.rs
@@ -52,6 +52,7 @@ pub struct MeasurementTracking {
     pub expected_probes: i32,
     pub sent_probes: i32,
     pub is_complete: bool,
+    pub cancelled: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -65,6 +66,7 @@ pub struct MeasurementStatus {
     pub total_sent_probes: i64,
     pub completed_agents: i64,
     pub measurement_complete: bool,
+    pub measurement_cancelled: bool,
     pub started_at: DateTime<Utc>,
     pub last_updated: DateTime<Utc>,
 }
@@ -592,7 +594,7 @@ impl Database {
                     r#"INSERT INTO measurement_tracking
                        (user_hash, measurement_id, agent_id, expected_probes, sent_probes, is_complete, created_at, updated_at)
                        VALUES ($1, $2, $3, $4, 0, false, $5, $5)
-                       RETURNING id, user_hash, measurement_id, agent_id, expected_probes, sent_probes, is_complete, created_at, updated_at"#
+                       RETURNING id, user_hash, measurement_id, agent_id, expected_probes, sent_probes, is_complete, cancelled, created_at, updated_at"#
                 )
                 .bind(user_hash)
                 .bind(measurement_id)
@@ -613,6 +615,7 @@ impl Database {
                     expected_probes,
                     sent_probes: 0,
                     is_complete: false,
+                    cancelled: false,
                     created_at: now,
                     updated_at: now,
                 };
@@ -641,7 +644,7 @@ impl Database {
                     r#"UPDATE measurement_tracking
                        SET sent_probes = $4, is_complete = $5, updated_at = $6
                        WHERE measurement_id = $1 AND user_hash = $2 AND agent_id = $3
-                       RETURNING id, user_hash, measurement_id, agent_id, expected_probes, sent_probes, is_complete, created_at, updated_at"#
+                       RETURNING id, user_hash, measurement_id, agent_id, expected_probes, sent_probes, is_complete, cancelled, created_at, updated_at"#
                 )
                 .bind(measurement_id)
                 .bind(user_hash)
@@ -690,6 +693,7 @@ impl Database {
                        total_sent_probes,
                        completed_agents,
                        measurement_complete,
+                       measurement_cancelled,
                        started_at,
                        last_updated
                        FROM measurement_status
@@ -718,7 +722,11 @@ impl Database {
                     records.iter().map(|r| r.expected_probes as i64).sum();
                 let total_sent_probes: i64 = records.iter().map(|r| r.sent_probes as i64).sum();
                 let completed_agents = records.iter().filter(|r| r.is_complete).count() as i64;
-                let measurement_complete = completed_agents == total_agents;
+                // Terminal when every agent is complete or cancelled (mirrors the view).
+                let terminal_agents =
+                    records.iter().filter(|r| r.is_complete || r.cancelled).count() as i64;
+                let measurement_complete = terminal_agents == total_agents;
+                let measurement_cancelled = records.iter().any(|r| r.cancelled);
                 let started_at = records.iter().map(|r| r.created_at).min().unwrap();
                 let last_updated = records.iter().map(|r| r.updated_at).max().unwrap();
 
@@ -730,6 +738,7 @@ impl Database {
                     total_sent_probes,
                     completed_agents,
                     measurement_complete,
+                    measurement_cancelled,
                     started_at,
                     last_updated,
                 }))
@@ -754,6 +763,7 @@ impl Database {
                        total_sent_probes,
                        completed_agents,
                        measurement_complete,
+                       measurement_cancelled,
                        started_at,
                        last_updated
                        FROM measurement_status
@@ -785,6 +795,8 @@ impl Database {
                         let total_agents = records.len() as i64;
                         let completed_agents =
                             records.iter().filter(|r| r.is_complete).count() as i64;
+                        let terminal_agents =
+                            records.iter().filter(|r| r.is_complete || r.cancelled).count() as i64;
                         MeasurementStatus {
                             measurement_id,
                             user_hash: user_hash.to_string(),
@@ -795,7 +807,8 @@ impl Database {
                                 .sum(),
                             total_sent_probes: records.iter().map(|r| r.sent_probes as i64).sum(),
                             completed_agents,
-                            measurement_complete: completed_agents == total_agents,
+                            measurement_complete: terminal_agents == total_agents,
+                            measurement_cancelled: records.iter().any(|r| r.cancelled),
                             started_at: records.iter().map(|r| r.created_at).min().unwrap(),
                             last_updated: records.iter().map(|r| r.updated_at).max().unwrap(),
                         }
@@ -809,6 +822,48 @@ impl Database {
         }
     }
 
+    /// Cancel a user's measurement by marking its not-yet-complete agent rows
+    /// as cancelled. Returns the number of rows changed (0 if the measurement is
+    /// already terminal — every agent already complete or cancelled).
+    pub async fn cancel_measurement(
+        &self,
+        measurement_id: Uuid,
+        user_hash: &str,
+    ) -> Result<u64, sqlx::Error> {
+        let now = Utc::now();
+        match &self.impl_ {
+            DatabaseImpl::Real(pool) => {
+                let result = sqlx::query(
+                    r#"UPDATE measurement_tracking
+                       SET cancelled = TRUE, updated_at = $3
+                       WHERE measurement_id = $1 AND user_hash = $2
+                         AND is_complete = FALSE AND cancelled = FALSE"#,
+                )
+                .bind(measurement_id)
+                .bind(user_hash)
+                .bind(now)
+                .execute(pool)
+                .await?;
+                Ok(result.rows_affected())
+            }
+            DatabaseImpl::Mock(storage) => {
+                let mut tracking = storage.measurement_tracking.lock().unwrap();
+                let mut affected = 0u64;
+                for record in tracking.iter_mut().filter(|t| {
+                    t.measurement_id == measurement_id
+                        && t.user_hash == user_hash
+                        && !t.is_complete
+                        && !t.cancelled
+                }) {
+                    record.cancelled = true;
+                    record.updated_at = now;
+                    affected += 1;
+                }
+                Ok(affected)
+            }
+        }
+    }
+
     /// Get all measurement tracking entries for a measurement
     pub async fn get_measurement_tracking(
         &self,
@@ -818,7 +873,7 @@ impl Database {
         match &self.impl_ {
             DatabaseImpl::Real(pool) => {
                 let records = sqlx::query_as::<_, MeasurementTracking>(
-                    r#"SELECT id, user_hash, measurement_id, agent_id, expected_probes, sent_probes, is_complete, created_at, updated_at
+                    r#"SELECT id, user_hash, measurement_id, agent_id, expected_probes, sent_probes, is_complete, cancelled, created_at, updated_at
                        FROM measurement_tracking
                        WHERE measurement_id = $1 AND user_hash = $2
                        ORDER BY created_at"#
@@ -853,7 +908,7 @@ impl Database {
         match &self.impl_ {
             DatabaseImpl::Real(pool) => {
                 let record = sqlx::query_as::<_, MeasurementTracking>(
-                    r#"SELECT id, user_hash, measurement_id, agent_id, expected_probes, sent_probes, is_complete, created_at, updated_at
+                    r#"SELECT id, user_hash, measurement_id, agent_id, expected_probes, sent_probes, is_complete, cancelled, created_at, updated_at
                        FROM measurement_tracking
                        WHERE measurement_id = $1 AND agent_id = $2"#
                 )
@@ -1278,6 +1333,48 @@ mod tests {
         let limited = db.list_user_measurements(user_hash, 1).await.unwrap();
         assert_eq!(limited.len(), 1);
         assert_eq!(limited[0].measurement_id, m2);
+    }
+
+    #[tokio::test]
+    async fn test_cancel_measurement() {
+        let db = Database::new_mock();
+        db.initialize().await.unwrap();
+        let user_hash = "test_user_hash";
+
+        // A stuck measurement: one agent that never completed.
+        let m = Uuid::new_v4();
+        db.create_measurement_tracking(user_hash, m, "agent1", 3000)
+            .await
+            .unwrap();
+
+        let before = db.get_measurement_status(m, user_hash).await.unwrap().unwrap();
+        assert!(!before.measurement_complete);
+        assert!(!before.measurement_cancelled);
+
+        // Cancel marks the unfinished agent row -> 1 row changed.
+        assert_eq!(db.cancel_measurement(m, user_hash).await.unwrap(), 1);
+
+        let after = db.get_measurement_status(m, user_hash).await.unwrap().unwrap();
+        assert!(after.measurement_complete); // terminal now
+        assert!(after.measurement_cancelled);
+        assert_eq!(after.completed_agents, 0); // cancelled is not "completed"
+
+        // Idempotent: a second cancel changes nothing.
+        assert_eq!(db.cancel_measurement(m, user_hash).await.unwrap(), 0);
+
+        // A different user cannot cancel someone else's measurement.
+        let other = Uuid::new_v4();
+        db.create_measurement_tracking(user_hash, other, "agent1", 10)
+            .await
+            .unwrap();
+        assert_eq!(db.cancel_measurement(other, "other_user").await.unwrap(), 0);
+        assert!(
+            !db.get_measurement_status(other, user_hash)
+                .await
+                .unwrap()
+                .unwrap()
+                .measurement_complete
+        );
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,10 @@ pub fn create_client_app(state: AppState) -> Router {
             "/measurement/{id}/status",
             get(get_measurement_status_handler),
         )
+        .route(
+            "/measurement/{id}/cancel",
+            post(cancel_measurement_handler),
+        )
         // .route("/admin/user-limit", post(set_user_limit))
         // .route("/admin/user-limit/:user_id", get(get_user_limit))
         .layer(axum::middleware::from_fn_with_state(
@@ -676,6 +680,7 @@ async fn list_measurements_handler(
                         "total_expected_probes": m.total_expected_probes,
                         "total_sent_probes": m.total_sent_probes,
                         "measurement_complete": m.measurement_complete,
+                        "measurement_cancelled": m.measurement_cancelled,
                         "started_at": m.started_at,
                         "last_updated": m.last_updated
                     })
@@ -744,6 +749,7 @@ async fn get_measurement_status_handler(
                         "expected_probes": t.expected_probes,
                         "sent_probes": t.sent_probes,
                         "is_complete": t.is_complete,
+                        "cancelled": t.cancelled,
                         "updated_at": t.updated_at
                     })
                 })
@@ -756,6 +762,7 @@ async fn get_measurement_status_handler(
                 "total_expected_probes": status.total_expected_probes,
                 "total_sent_probes": status.total_sent_probes,
                 "measurement_complete": status.measurement_complete,
+                "measurement_cancelled": status.measurement_cancelled,
                 "started_at": status.started_at,
                 "last_updated": status.last_updated,
                 "agents": agents_detail
@@ -775,6 +782,89 @@ async fn get_measurement_status_handler(
                 Json(serde_json::json!({
                     "error": 500,
                     "message": "Failed to retrieve measurement status"
+                })),
+            ))
+        }
+    }
+}
+
+// Handler for cancelling a user's stuck/in-progress measurement (client-facing)
+async fn cancel_measurement_handler(
+    Extension(auth_info): Extension<jwt::AuthInfo>,
+    State(state): State<AppState>,
+    Path(measurement_id): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let measurement_uuid = match Uuid::parse_str(&measurement_id) {
+        Ok(uuid) => uuid,
+        Err(_) => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": 400,
+                    "message": "Invalid measurement ID format"
+                })),
+            ));
+        }
+    };
+
+    let user_hash = crate::hash_user_identifier(&auth_info.sub);
+
+    // Look the measurement up first so we can 404 if it isn't this user's, and
+    // no-op if it's already terminal.
+    let status = match state
+        .database
+        .get_measurement_status(measurement_uuid, &user_hash)
+        .await
+    {
+        Ok(Some(status)) => status,
+        Ok(None) => {
+            return Err((
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({
+                    "error": 404,
+                    "message": "Measurement not found"
+                })),
+            ));
+        }
+        Err(err) => {
+            error!("Failed to look up measurement before cancel: {}", err);
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": 500,
+                    "message": "Failed to cancel measurement"
+                })),
+            ));
+        }
+    };
+
+    if status.measurement_complete {
+        return Ok(Json(serde_json::json!({
+            "measurement_id": measurement_uuid,
+            "cancelled": false,
+            "agents_cancelled": 0,
+            "message": "Measurement already complete; nothing to cancel"
+        })));
+    }
+
+    match state
+        .database
+        .cancel_measurement(measurement_uuid, &user_hash)
+        .await
+    {
+        Ok(agents_cancelled) => Ok(Json(serde_json::json!({
+            "measurement_id": measurement_uuid,
+            "cancelled": true,
+            "agents_cancelled": agents_cancelled,
+            "message": "Measurement cancelled"
+        }))),
+        Err(err) => {
+            error!("Failed to cancel measurement: {}", err);
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": 500,
+                    "message": "Failed to cancel measurement"
                 })),
             ))
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -838,12 +838,21 @@ async fn cancel_measurement_handler(
         }
     };
 
+    // Already terminal (every agent complete or cancelled) — nothing to cancel.
+    // `cancelled` here means "did this call cancel it" (it didn't); the actual
+    // state is reported via `measurement_cancelled`.
     if status.measurement_complete {
+        let message = if status.measurement_cancelled {
+            "Measurement already cancelled"
+        } else {
+            "Measurement already complete; nothing to cancel"
+        };
         return Ok(Json(serde_json::json!({
             "measurement_id": measurement_uuid,
             "cancelled": false,
+            "measurement_cancelled": status.measurement_cancelled,
             "agents_cancelled": 0,
-            "message": "Measurement already complete; nothing to cancel"
+            "message": message
         })));
     }
 
@@ -852,9 +861,19 @@ async fn cancel_measurement_handler(
         .cancel_measurement(measurement_uuid, &user_hash)
         .await
     {
+        // 0 rows means the measurement became terminal between our status read and
+        // the UPDATE (an agent finished, or a concurrent cancel won) — this call
+        // did not cancel anything, so don't claim it did.
+        Ok(0) => Ok(Json(serde_json::json!({
+            "measurement_id": measurement_uuid,
+            "cancelled": false,
+            "agents_cancelled": 0,
+            "message": "Measurement already terminal; nothing to cancel"
+        }))),
         Ok(agents_cancelled) => Ok(Json(serde_json::json!({
             "measurement_id": measurement_uuid,
             "cancelled": true,
+            "measurement_cancelled": true,
             "agents_cancelled": agents_cancelled,
             "message": "Measurement cancelled"
         }))),


### PR DESCRIPTION
Lets a user resolve their own **stuck / in-progress measurements** — surfaced from a real one: an agent (`vltsyd01`) died mid-run on 2026-03-22 and never reported, so the measurement shows "in progress" forever with no way to clear it. (roadmap nxthdr/roadmap#38)

## Changes
- **Migration** `20260619000001_add_measurement_cancellation.sql`: adds `measurement_tracking.cancelled`; recreates the `measurement_status` view so a measurement is terminal when every agent is **complete OR cancelled**, and exposes `measurement_cancelled`.
- **`cancel_measurement(id, user_hash)`**: marks the not-yet-complete agent rows `cancelled` (idempotent, user-scoped). Real + Mock + unit test (`test_cancel_measurement`).
- **`POST /api/measurement/{id}/cancel`**: JWT-scoped — `404` if not the caller's measurement, no-op if already terminal, otherwise cancels and reports `agents_cancelled`.
- `list` + `status` responses now carry `measurement_cancelled` (and per-agent `cancelled`), so clients can show a distinct **"cancelled"** status rather than mislabeling it "complete".

## Testing
`cargo check --locked` clean, `cargo test --lib` green (incl. new cancel test), clippy clean.

Paired with the CLI `probing cancel <id>` command (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)