### PR TITLE
hotfix: measurement_status migration (DROP+CREATE VIEW)

### DIFF
--- a/migrations/20260619000001_add_measurement_cancellation.sql
+++ b/migrations/20260619000001_add_measurement_cancellation.sql
@@ -8,7 +8,10 @@ ALTER TABLE measurement_tracking
 
 -- Recreate the status view: a measurement is terminal ("complete") when every
 -- agent is either complete or cancelled, and expose whether it was cancelled.
-CREATE OR REPLACE VIEW measurement_status AS
+-- DROP + CREATE (not CREATE OR REPLACE): Postgres forbids reordering/renaming an
+-- existing view's columns via CREATE OR REPLACE, and we add a column mid-list.
+DROP VIEW IF EXISTS measurement_status;
+CREATE VIEW measurement_status AS
 SELECT
     measurement_id,
     user_hash,


### PR DESCRIPTION
**Prod hotfix.** Migration `20260619000001` crash-looped the gateway: `CREATE OR REPLACE VIEW` can't add a column mid-list (`cannot change name of view column "started_at" to "measurement_cancelled"`). Switched to `DROP VIEW IF EXISTS` + `CREATE VIEW`, which allows the new column order. Idempotent; the failed migration rolled back transactionally so it re-applies cleanly.

Note: gateway CI runs unit tests against the **mock DB only** — migrations never run against real Postgres in CI, so this wasn't caught. (Follow-up worth considering: a CI step that applies migrations to a throwaway Postgres.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)