### PR TITLE
ci: test migrations against a real Postgres

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -20,6 +20,35 @@ jobs:
         cargo check --locked
         cargo test --locked --verbose
 
+  # Apply every migration in order to a throwaway Postgres so a broken migration
+  # fails CI instead of crash-looping the gateway on deploy. The unit tests above
+  # use the in-memory mock DB and never exercise the real SQL/migrations.
+  migrations:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: saimiris_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v7
+      - name: Apply migrations to a fresh Postgres
+        env:
+          PGPASSWORD: postgres
+        run: |
+          for f in $(ls migrations/*.sql | sort); do
+            echo "==> applying $f"
+            psql -h localhost -U postgres -d saimiris_ci -v ON_ERROR_STOP=1 --single-transaction -f "$f"
+          done
+
   docker:
     strategy:
       fail-fast: false
@@ -32,7 +61,7 @@ jobs:
       id-token: write
 
     runs-on: ${{ matrix.os.name }}
-    needs: [ tests ]
+    needs: [ tests, migrations ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -44,7 +44,11 @@ jobs:
         env:
           PGPASSWORD: postgres
         run: |
-          for f in $(ls migrations/*.sql | sort); do
+          # Glob expansion is already sorted lexicographically (matches the
+          # NNNNN_ migration naming). --single-transaction wraps each file in a
+          # transaction: do NOT add a migration that must run outside one (e.g.
+          # CREATE INDEX CONCURRENTLY) without revisiting this.
+          for f in migrations/*.sql; do
             echo "==> applying $f"
             psql -h localhost -U postgres -d saimiris_ci -v ON_ERROR_STOP=1 --single-transaction -f "$f"
           done


### PR DESCRIPTION
Adds a `migrations` CI job that spins up a throwaway Postgres and applies every `migrations/*.sql` **in order** (each in a transaction, `ON_ERROR_STOP`). `docker` now depends on it, so a broken migration fails CI **before** an image is built/pushed.

**Why:** the cancel migration (#47) used `CREATE OR REPLACE VIEW` to reorder a view's columns — illegal in Postgres — and crash-looped the gateway on deploy. CI never caught it because the unit tests only use the in-memory mock DB and never run the real SQL/migrations. This job exercises them.

This PR's own run is the first test of the job — it applies the full (now-fixed) migration set to a fresh PG16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)