### PR TITLE
fix: connect to Postgres over bracketed IPv6 literal DB URLs

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -1,5 +1,6 @@
 use crate::hash_user_identifier;
 use chrono::{DateTime, Utc};
+use sqlx::postgres::PgConnectOptions;
 use sqlx::{PgPool, Row};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -274,9 +275,27 @@ pub struct Database {
     impl_: DatabaseImpl,
 }
 
+/// Build Postgres connection options from a URL, working around a regression in
+/// sqlx 0.9: a bracketed IPv6 literal host (e.g. `postgresql://[2a06:de00:…]:5432/db`)
+/// is stored — and handed to the resolver — with the `[ ]` still attached, so
+/// getaddrinfo fails with "Name or service not known". sqlx 0.8 trimmed the brackets
+/// in `connect_tcp`; 0.9 dropped that, so we trim them here before connecting.
+/// See nxthdr/saimiris-gateway#55 (and the sister regression peerlab-gateway#97).
+fn connect_options(database_url: &str) -> Result<PgConnectOptions, sqlx::Error> {
+    let options: PgConnectOptions = database_url.parse()?;
+    let host = options.get_host();
+    let unbracketed = host.trim_matches(|c| c == '[' || c == ']');
+    if unbracketed.len() == host.len() {
+        Ok(options)
+    } else {
+        let unbracketed = unbracketed.to_string();
+        Ok(options.host(&unbracketed))
+    }
+}
+
 impl Database {
     pub async fn new(config: &DatabaseConfig) -> Result<Self, sqlx::Error> {
-        let pool = PgPool::connect(&config.database_url).await?;
+        let pool = PgPool::connect_with(connect_options(&config.database_url)?).await?;
         Ok(Self {
             impl_: DatabaseImpl::Real(pool),
         })
@@ -1057,6 +1076,28 @@ impl Database {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Regression test for #55: a bracketed IPv6 literal host must reach the resolver
+    // without its `[ ]`, otherwise sqlx 0.9 hands `[2a06:…]` to getaddrinfo and the
+    // gateway crash-loops with "Name or service not known". Runs in the normal
+    // `cargo test` job with no database needed.
+    #[test]
+    fn connect_options_strips_brackets_from_ipv6_literal_host() {
+        let opts = connect_options("postgresql://u:p@[2a06:de00:50:cafe:10::116]:5432/saimiris")
+            .expect("parse bracketed IPv6 URL");
+        assert_eq!(opts.get_host(), "2a06:de00:50:cafe:10::116");
+
+        let loopback =
+            connect_options("postgresql://u:p@[::1]:5432/saimiris").expect("parse [::1] URL");
+        assert_eq!(loopback.get_host(), "::1");
+    }
+
+    #[test]
+    fn connect_options_leaves_plain_host_untouched() {
+        let opts = connect_options("postgresql://u:p@db.example.com:5432/saimiris")
+            .expect("parse hostname URL");
+        assert_eq!(opts.get_host(), "db.example.com");
+    }
 
     #[test]
     fn test_hash_user_id() {


### PR DESCRIPTION
## Summary

Fixes #55 — `:main` crash-looped on startup because it could no longer connect to PostgreSQL via a **bracketed IPv6 literal** `--database-url` (`postgresql://[2a06:…]:5432/db`), failing with `getaddrinfo … Name or service not known`.

## Root cause

A regression in the **sqlx 0.9 upgrade** (#35). In `sqlx-core` 0.8.6, `connect_tcp` trimmed the URL brackets before resolving:

```rust
// IPv6 addresses in URLs will be wrapped in brackets and the `url` crate doesn't trim those.
let host = host.trim_matches(&['[', ']'][..]);
```

`sqlx-core` 0.9.0 **dropped that line**, so the literal `[2a06:…]` is handed straight to `getaddrinfo` → resolve failure. `0.9.0` is the latest release, so there's no patched version to bump to.

## Fix

Stay on sqlx 0.9 and restore the trim ourselves: `database.rs` parses the URL into `PgConnectOptions`, strips `[ ]` from the host, and uses `connect_with`. It's a no-op for plain hostnames and harmless on 0.8, so it survives a Renovate version flip in either direction.

## Testing

The `migrations` CI job only ran `psql -h localhost` (IPv4) — it tested the SQL files, never the gateway's own connect path, and never a bracketed IPv6 host, so this path had zero coverage.

Added unit tests (run in the normal `cargo test` job, no DB) asserting `connect_options(...)` strips the brackets from an IPv6 literal host (`[2a06:…]`, `[::1]`) and leaves plain hostnames untouched. They fail if the workaround is ever removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)