### PR TITLE
fix: stop logging Postgres password on startup

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -293,6 +293,25 @@ fn connect_options(database_url: &str) -> Result<PgConnectOptions, sqlx::Error> 
     }
 }
 
+/// Render a log-safe description of the database target — host, port, and database
+/// name only — so the password embedded in the connection URL is never logged.
+/// Falls back to a placeholder if the URL can't be parsed.
+pub fn safe_database_target(database_url: &str) -> String {
+    let Ok(options) = connect_options(database_url) else {
+        return "<unparseable database url>".to_string();
+    };
+    let host = options.get_host();
+    let host = if host.contains(':') {
+        format!("[{host}]")
+    } else {
+        host.to_string()
+    };
+    match options.get_database() {
+        Some(db) => format!("{host}:{}/{db}", options.get_port()),
+        None => format!("{host}:{}", options.get_port()),
+    }
+}
+
 impl Database {
     pub async fn new(config: &DatabaseConfig) -> Result<Self, sqlx::Error> {
         let pool = PgPool::connect_with(connect_options(&config.database_url)?).await?;
@@ -1097,6 +1116,24 @@ mod tests {
         let opts = connect_options("postgresql://u:p@db.example.com:5432/saimiris")
             .expect("parse hostname URL");
         assert_eq!(opts.get_host(), "db.example.com");
+    }
+
+    // The startup log line must never carry the password embedded in the URL.
+    #[test]
+    fn safe_database_target_omits_password() {
+        let target = safe_database_target(
+            "postgresql://[2a06:de00:50:cafe:10::116]:5432/saimiris?user=postgres&password=hunter2&sslmode=disable",
+        );
+        assert!(!target.contains("hunter2"), "password leaked in {target}");
+        assert!(!target.contains("password"), "credential leaked in {target}");
+        assert_eq!(target, "[2a06:de00:50:cafe:10::116]:5432/saimiris");
+    }
+
+    #[test]
+    fn safe_database_target_handles_plain_host() {
+        let target = safe_database_target("postgresql://u:secret@db.example.com:5432/saimiris");
+        assert!(!target.contains("secret"), "password leaked in {target}");
+        assert_eq!(target, "db.example.com:5432/saimiris");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use saimiris_gateway::{
     AppState,
     agent::AgentStore,
     create_app,
-    database::{Database, DatabaseConfig},
+    database::{Database, DatabaseConfig, safe_database_target},
     kafka,
 };
 
@@ -193,7 +193,10 @@ async fn main() -> anyhow::Result<()> {
     let database_config = DatabaseConfig::new(cli.database_url.clone());
     let database = match Database::new(&database_config).await {
         Ok(db) => {
-            info!("Connected to database: {}", cli.database_url);
+            info!(
+                "Connected to database: {}",
+                safe_database_target(&cli.database_url)
+            );
 
             // Run database migrations automatically
             info!("Running database migrations...");


### PR DESCRIPTION
## Problem
The gateway logged the full `--database-url` at `INFO` on startup:

```
Connected to database: postgresql://[host]:5432/<db>?user=postgres&password=<secret>&sslmode=disable
```

The DSN embeds the Postgres password, so the credential was written to container stdout on every boot and ingested into Loki (queryable via `loki.nxthdr.dev` / Grafana). It re-logs on each restart.

## Fix
- New `safe_database_target()` in `database.rs` — reuses the existing `connect_options()` parser and returns only `host:port/db` (IPv6 re-bracketed), with a `<unparseable database url>` fallback.
- `main.rs` now logs `safe_database_target(&cli.database_url)` instead of the raw URL.
- Regression tests assert the password string never appears in the rendered target.

New log line: `Connected to database: [2a06:de00:…::116]:5432/saimiris`.

## Verification
`cargo check --locked` clean; `cargo test --locked safe_database_target` → 2 passed.

## Follow-up (not in this PR)
The currently-exposed password should be **rotated** — it has already been written to Loki.

🤖 Generated with [Claude Code](https://claude.com/claude-code)